### PR TITLE
'fix' movies routing

### DIFF
--- a/nrc-18307/lab-martes/movies-hex-backend/src/movies/infrastructure/express/controller/MovieControllerExpress.ts
+++ b/nrc-18307/lab-martes/movies-hex-backend/src/movies/infrastructure/express/controller/MovieControllerExpress.ts
@@ -9,6 +9,7 @@ export default class MovieControllerExpress
   constructor(private readonly movieUseCase: MovieUseCasePort) {}
 
   getMovies(_req: Request, res: Response): void {
+    console.log("I got this way")
     const movies = this.movieUseCase.getMovies()
     const movies_json = MoviesToJson.get(movies)
 

--- a/nrc-18307/lab-martes/movies-hex-backend/src/movies/infrastructure/express/router/MovieRouterExpress.ts
+++ b/nrc-18307/lab-martes/movies-hex-backend/src/movies/infrastructure/express/router/MovieRouterExpress.ts
@@ -17,10 +17,10 @@ export default class MovieRouterExpress implements MovieRouterExpressInterface {
   }
 
   public getMovies(): void {
-    this.router.get(`${this.path}/movies`, this.controller.getMovies.bind(this.controller))
+    this.router.get(`/`, this.controller.getMovies.bind(this.controller))
   }
 
   public getMovieById(): void {
-    this.router.get(`${this.path}/movie/:id`, this.controller.getMovieById.bind(this.controller))
+    this.router.get(`/:id`, this.controller.getMovieById.bind(this.controller))
   }
 }


### PR DESCRIPTION
mistake was on naming 'this.path' inside the router
cause it was already on the url.

example :
   `    this.path = '/movies'
`
was on:
`        this.router.get('${this.path}/movies', this.controller.getMovies.bind(this.controller))
`
so the url would be http://localhost:1802/movies/movies/movies/
which we didn't realize atm